### PR TITLE
Feat: Update homepage summary with Blizzard role

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <header>
             <h1>Hagyoon Choi - Software Engineer</h1>
             <p>
-                With over 15 years of experience in software development, primarily in game development and publishing, I bring a versatile skill set applicable to diverse challenges. My recent work at Twitter involved platform engineering, contributing to large-scale service infrastructure. I am passionate about continuous learning, particularly in mathematics and physics, and enjoy applying this knowledge to create innovative solutions.
+                With over 15 years of experience in software development, primarily in game development and publishing, I bring a versatile skill set applicable to diverse challenges. My work includes platform engineering at Twitter, and prior to that, I served as a Senior Software Engineer at Blizzard Entertainment on an unannounced survival project. I am passionate about continuous learning, particularly in mathematics and physics, and enjoy applying this knowledge to create innovative solutions.
             </p>
         </header>
 


### PR DESCRIPTION
This commit modifies the professional summary on index.html to include previous experience as a Senior Software Engineer at Blizzard Entertainment on an unannounced survival project.